### PR TITLE
Add Karma process API and core engine skeleton

### DIFF
--- a/lib/core/karmaEngine.ts
+++ b/lib/core/karmaEngine.ts
@@ -1,0 +1,21 @@
+// lib/core/karmaEngine.ts
+// Zentraler Ablauf für die Karma-Verarbeitung
+
+import { Logger } from '../utils/logger'
+import { WorkflowError } from '../utils/errorTypes'
+
+// Example type import; actual interfaces live in /types
+import type { KarmaMetadata, KarmaResult } from '../../types/karma'
+
+const logger = new Logger({ level: 'INFO' })
+
+export async function runKarmaPipeline(text: string, metadata?: KarmaMetadata): Promise<KarmaResult> {
+  try {
+    logger.info('Running Karma pipeline')
+    // TODO: Implement real processing logic
+    return { message: 'Pipeline executed', input: text, metadata }
+  } catch (err) {
+    logger.error(`Karma pipeline failed: ${err}`)
+    throw new WorkflowError('Karma pipeline execution failed')
+  }
+}

--- a/pages/api/karma/process.ts
+++ b/pages/api/karma/process.ts
@@ -1,0 +1,23 @@
+// pages/api/karma/process.ts
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { runKarmaPipeline } from '@/lib/core/karmaEngine'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed. Use POST.' })
+  }
+
+  const { text, metadata } = req.body
+
+  if (!text || typeof text !== 'string') {
+    return res.status(400).json({ error: 'Missing or invalid `text` in request body.' })
+  }
+
+  try {
+    const result = await runKarmaPipeline(text, metadata)
+    res.status(200).json({ success: true, result })
+  } catch (err) {
+    console.error('[KARMA PROCESS ERROR]', err)
+    res.status(500).json({ error: 'Internal processing error', details: String(err) })
+  }
+}

--- a/types/karma.d.ts
+++ b/types/karma.d.ts
@@ -1,0 +1,12 @@
+// types/karma.d.ts
+// Gemeinsame Schnittstellen und Typdefinitionen für das Karma-System
+
+export interface KarmaMetadata {
+  [key: string]: any
+}
+
+export interface KarmaResult {
+  message: string
+  input: string
+  metadata?: KarmaMetadata
+}


### PR DESCRIPTION
## Summary
- implement API route at `pages/api/karma/process.ts`
- add core `runKarmaPipeline` function in `lib/core/karmaEngine.ts`
- define shared interfaces in `types/karma.d.ts`

## Testing
- `npm test` *(fails: "Error: no test specified")*
- `npx tsc --noEmit` *(fails: Cannot find module 'next' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68460e6246f0832395dc3839683b3656