### PR TITLE
Implement missing karma API routes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,12 @@
 # API Documentation
 
-This file will document the HTTP API endpoints.
+Overview of available endpoints.
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| POST | `/api/karma/process` | Analyse document and build knowledge graph |
+| GET | `/api/karma/status` | Status and logs from the last run |
+| GET | `/api/karma/export` | Export the knowledge graph |
+| GET | `/api/karma/monitor` | Live agent status, errors and debug data |
 
 <!-- Axolotl – Empowered by satoshiflow. -->

--- a/lib/core/karmaEngine.ts
+++ b/lib/core/karmaEngine.ts
@@ -3,6 +3,7 @@
 
 import { Logger } from '../utils/logger'
 import { WorkflowError } from '../utils/errorTypes'
+import { karmaState } from './karmaState'
 
 // Example type import; actual interfaces live in /types
 import type { KarmaMetadata, KarmaResult } from '../../types/karma'
@@ -12,10 +13,18 @@ const logger = new Logger({ level: 'INFO' })
 export async function runKarmaPipeline(text: string, metadata?: KarmaMetadata): Promise<KarmaResult> {
   try {
     logger.info('Running Karma pipeline')
+    karmaState.logs.push('Running Karma pipeline')
     // TODO: Implement real processing logic
-    return { message: 'Pipeline executed', input: text, metadata }
+    const result = { message: 'Pipeline executed', input: text, metadata }
+    karmaState.lastResult = result
+    karmaState.graph = [`<${text}> <processed> <graph>`]
+    karmaState.lastError = undefined
+    karmaState.logs.push('Pipeline executed')
+    return result
   } catch (err) {
     logger.error(`Karma pipeline failed: ${err}`)
+    karmaState.lastError = String(err)
+    karmaState.logs.push(`Error: ${err}`)
     throw new WorkflowError('Karma pipeline execution failed')
   }
 }

--- a/lib/core/karmaState.ts
+++ b/lib/core/karmaState.ts
@@ -1,0 +1,11 @@
+export interface KarmaState {
+  lastResult?: import('../../types/karma').KarmaResult
+  logs: string[]
+  lastError?: string
+  graph: string[]
+}
+
+export const karmaState: KarmaState = {
+  logs: [],
+  graph: []
+}

--- a/pages/api/karma/export.ts
+++ b/pages/api/karma/export.ts
@@ -1,0 +1,16 @@
+// pages/api/karma/export.ts
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { karmaState } from '@/lib/core/karmaState'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed. Use GET.' })
+  }
+
+  const format = (req.query.format as string) || 'json'
+  if (format !== 'json') {
+    return res.status(400).json({ error: 'Only json export supported in demo.' })
+  }
+
+  res.status(200).json({ graph: karmaState.graph })
+}

--- a/pages/api/karma/monitor.ts
+++ b/pages/api/karma/monitor.ts
@@ -1,0 +1,15 @@
+// pages/api/karma/monitor.ts
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { karmaState } from '@/lib/core/karmaState'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed. Use GET.' })
+  }
+
+  res.status(200).json({
+    agents: { running: true },
+    errors: karmaState.lastError,
+    debug: karmaState.logs
+  })
+}

--- a/pages/api/karma/status.ts
+++ b/pages/api/karma/status.ts
@@ -1,0 +1,15 @@
+// pages/api/karma/status.ts
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { karmaState } from '@/lib/core/karmaState'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed. Use GET.' })
+  }
+
+  res.status(200).json({
+    lastResult: karmaState.lastResult,
+    logs: karmaState.logs,
+    lastError: karmaState.lastError
+  })
+}


### PR DESCRIPTION
## Summary
- add API documentation for karma endpoints
- track processing results in `karmaState`
- update `runKarmaPipeline` to record state
- implement `/api/karma/status`, `/api/karma/export`, `/api/karma/monitor` routes

## Testing
- `npm test` *(fails: vitest permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68461cb3de0083239e99d7a5b15e23aa