### PR TITLE
Add missing segmentation and summarization agents

### DIFF
--- a/lib/agents/ContentSegmentationAgent.ts
+++ b/lib/agents/ContentSegmentationAgent.ts
@@ -1,0 +1,31 @@
+// Axolotl – Empowered by satoshiflow
+// ContentSegmentationAgent – Splits a text into meaningful segments
+
+import { Logger } from '../utils/logger'
+import { AgentError } from '../utils/errorTypes'
+
+export interface SegmentationResult {
+  segments: string[]
+}
+
+export class ContentSegmentationAgent {
+  private logger: Logger
+
+  constructor(debug = false) {
+    this.logger = new Logger({ level: 'INFO', debug })
+  }
+
+  public segment(text: string): SegmentationResult {
+    if (!text) throw new AgentError('No text provided')
+
+    let segments = text.split(/\n\s*\n/).map(s => s.trim()).filter(Boolean)
+
+    if (segments.length === 1) {
+      segments = text.split(/(?<=[.!?])\s+/).map(s => s.trim()).filter(Boolean)
+    }
+
+    this.logger.debugLog(`[ContentSegmentationAgent] Segments: ${segments.length}`)
+
+    return { segments }
+  }
+}

--- a/lib/agents/ContentSummarizationAgent.ts
+++ b/lib/agents/ContentSummarizationAgent.ts
@@ -1,0 +1,33 @@
+// Axolotl – Empowered by satoshiflow
+// ContentSummarizationAgent – Creates concise summaries for text segments
+
+import { Logger } from '../utils/logger'
+import { AgentError } from '../utils/errorTypes'
+
+export interface SummarizationResult {
+  summaries: string[]
+}
+
+export class ContentSummarizationAgent {
+  private logger: Logger
+
+  constructor(debug = false) {
+    this.logger = new Logger({ level: 'INFO', debug })
+  }
+
+  public summarize(segments: string[]): SummarizationResult {
+    if (!segments || segments.length === 0) {
+      throw new AgentError('No segments provided')
+    }
+
+    const summaries = segments.map(seg => {
+      const words = seg.split(/\s+/).filter(Boolean)
+      const summary = words.slice(0, 10).join(' ')
+      return words.length > 10 ? summary + '...' : summary
+    })
+
+    this.logger.debugLog(`[ContentSummarizationAgent] Summaries: ${summaries.length}`)
+
+    return { summaries }
+  }
+}

--- a/tests/agents/ContentSegmentationAgent.test.ts
+++ b/tests/agents/ContentSegmentationAgent.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { ContentSegmentationAgent } from '../../lib/agents/ContentSegmentationAgent'
+
+describe('ContentSegmentationAgent', () => {
+  const agent = new ContentSegmentationAgent(true)
+
+  it('should split text into separate segments', () => {
+    const input = 'Absatz eins.\n\nAbsatz zwei.'
+    const result = agent.segment(input)
+    expect(result.segments.length).toBe(2)
+    expect(result.segments[0]).toContain('Absatz eins')
+  })
+
+  it('should fallback to sentence splitting', () => {
+    const input = 'Satz eins. Satz zwei?'
+    const result = agent.segment(input)
+    expect(result.segments.length).toBeGreaterThan(1)
+  })
+})

--- a/tests/agents/ContentSummarizationAgent.test.ts
+++ b/tests/agents/ContentSummarizationAgent.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { ContentSummarizationAgent } from '../../lib/agents/ContentSummarizationAgent'
+
+describe('ContentSummarizationAgent', () => {
+  const agent = new ContentSummarizationAgent(true)
+
+  it('should create summaries for each segment', () => {
+    const segments = [
+      'Albert Einstein war ein theoretischer Physiker.',
+      'Er entwickelte die Relativitätstheorie und erhielt den Nobelpreis.'
+    ]
+    const result = agent.summarize(segments)
+    expect(result.summaries.length).toBe(segments.length)
+    expect(result.summaries[0].length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary
- implement `ContentSegmentationAgent` for splitting documents into segments
- implement `ContentSummarizationAgent` to create short summaries
- add unit tests for both new agents

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6846227d16748323956ccc2a90b1ed92